### PR TITLE
Add support for custom DSN connection to PostgresThis commit adds sup…

### DIFF
--- a/app/backend/main.go
+++ b/app/backend/main.go
@@ -26,13 +26,18 @@ type Options struct {
     MaxExpire time.Duration `long:"expire" env:"MAX_EXPIRE" default:"24h" description:"max lifetime"`
     MaxPinAttempts int `long:"pinattempts" env:"PIN_ATTEMPTS" default:"3" description:"max attempts to enter pin"`
     WebRoot string `long:"web" env:"WEB" default:"/" description:"web ui location"`
+    Dsn string `long:"dsn" env:"POSTGRES_DSN" description:"dsn connection to postgres"`
 }
 
 var revision string
 
 func main() {
-    if err := godotenv.Load(); err != nil {
-        panic("No .env file found")
+    if opts.Dsn == "" {
+        if err := godotenv.Load(); err != nil {
+            panic("No .env file found")
+        }
+    } else {
+        os.Setenv("POSTGRES_DSN", opts.Dsn)
     }
 
     var opts Options


### PR DESCRIPTION
…port for specifying a custom DSN connectionto Postgres by introducing a new flag `--dsn` in the `Options`struct. If the `--dsn` flag is provided, the value is set as theenvironment variable `POSTGRES_DSN`. If the `--dsn` flag is notprovided, the `.env` file is loaded as usual